### PR TITLE
marginaleffects: hypothesis formula syntax

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Description: Generates balancing weights for causal effect estimation in observa
              with the 'cobalt' package. Methods for estimating weighted regression models that take into account 
              uncertainty in the estimation of the weights via M-estimation or bootstrapping are available. See the vignette "Installing Supporting Packages" for instructions on how
              to install any package 'WeightIt' uses, including those that may not be on CRAN.
+Remotes: vincentarelbundock/marginaleffects
 Depends:
     R (>= 4.0.0)
 Imports:
@@ -40,7 +41,7 @@ Suggests:
     survival (>= 3.6-2),
     fwb (>= 0.2.0),
     splines,
-    marginaleffects (>= 0.19.0),
+    marginaleffects (>= 0.25.0),
     sandwich,
     MASS,
     gbm (>= 2.1.3),

--- a/vignettes/estimating-effects.Rmd
+++ b/vignettes/estimating-effects.Rmd
@@ -246,7 +246,7 @@ avg_predictions(fit, variables = "A")
 
 We can see that the difference in potential outcome means is equal to the average treatment effect computed previously[^2]. The arguments to `avg_predictions()` are the same as those to `avg_comparisons()`.
 
-[^2]: To verify that they are equal, supply the output of `avg_predictions()` to `hypotheses()`, e.g., `avg_predictions(...) |> hypotheses("revpairwise")`; this explicitly compares the average potential outcomes and should yield identical estimates to the `avg_comparisons()` call.
+[^2]: To verify that they are equal, supply the output of `avg_predictions()` to `hypotheses()`, e.g., `avg_predictions(...) |> hypotheses(~revpairwise)`; this explicitly compares the average potential outcomes and should yield identical estimates to the `avg_comparisons()` call.
 
 ### Adjustments to the Standard Case
 
@@ -408,7 +408,7 @@ p <- avg_predictions(fit,
                      newdata = subset(Am == "T"))
 p
 
-hypotheses(p, "revpairwise")
+hypotheses(p, ~revpairwise)
 ```
 
 We find significant ATTs between the focal treatment and control levels (`T - C1` and `T - C2`), but the difference between control levels (`C2 - C1`), which can be interpreted as the difference between these ATTs, is nonsignificant, as expected.
@@ -530,7 +530,7 @@ Then, we compute the average expected potential outcomes under each treatment re
 We can compare individual predictions using `marginaleffects::hypotheses()`. For example, to compare all treatment histories to just the first treatment history (i.e., in which all units are untreated for all time periods), we can run the following:
 
 ```{r, eval = me_ok}
-hypotheses(p, "reference")
+hypotheses(p, ~reference)
 ```
 
 ### Moderation Analysis
@@ -575,7 +575,7 @@ We can see that the subgroup mean differences differ from each other, and we can
 ```{r, eval = me_ok}
 avg_comparisons(fit, variables = "A",
                 by = "X5",
-                hypothesis = "pairwise")
+                hypothesis = ~revpairwise)
 ```
 
 Though the subgroup effects differ from each other in the sample, this difference is not statistically significant at the .05 level, so there is no evidence of moderation by `X5`.
@@ -585,7 +585,7 @@ When the moderator has more than two levels, it is possible to run an omnibus te
 ```{r, eval=FALSE}
 avg_comparisons(fit, variables = "A",
                 by = "X5",
-                hypothesis = "reference") |>
+                hypothesis = ~reference) |>
   hypotheses(joint = TRUE)
 ```
 


### PR DESCRIPTION
I'm gearing up to release version 1.0.0 of `marginaleffects` and planning to keep the interface *much* more stable from then on. To get there, I'm making a few minor breaking changes. 

One of them will bite the vignettes in `WeightIt`: Use the formula syntax in the `hypothesis` argument. For example,

```r
avg_predictions(mod, by = "x", hypothesis = "revpairwise")
```

becomes

```r
avg_predictions(mod, by = "x", hypothesis = ~revpairwise)
```

This PR modifies your vignette and adds a `Remotes` line to `DESCRIPTION`. This line should be removed after release of `marginaleffects` 0.25.0, and before submitting `WeighIt` to CRAN.

Sorry for the trouble!